### PR TITLE
Handle Multi to Flux adapters because of Reactor using legacy APIs

### DIFF
--- a/commands/deployment/src/main/java/io/quarkiverse/discord4j/commands/deployment/Discord4jCommandsProcessor.java
+++ b/commands/deployment/src/main/java/io/quarkiverse/discord4j/commands/deployment/Discord4jCommandsProcessor.java
@@ -215,7 +215,7 @@ public class Discord4jCommandsProcessor {
                     Discord4jUtils.getBeanInstance(mc, method.declaringClass().name().toString()),
                     mc.checkCast(mc.getMethodParam(0), method.parameterTypes().get(0).name().toString()));
 
-            mc.returnValue(Discord4jUtils.convertIfUni(method.returnType().name().toString(), mc, publisher));
+            mc.returnValue(Discord4jUtils.convertIfMutinyTypes(method.returnType().name().toString(), mc, publisher));
             cc.close();
         }
 

--- a/deployment/src/main/java/io/quarkiverse/discord4j/deployment/Discord4jMethodDescriptors.java
+++ b/deployment/src/main/java/io/quarkiverse/discord4j/deployment/Discord4jMethodDescriptors.java
@@ -9,7 +9,10 @@ import discord4j.core.GatewayDiscordClient;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.gizmo.MethodDescriptor;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.converters.multi.MultiReactorConverters;
+import io.smallrye.mutiny.converters.multi.ToFlux;
 import io.smallrye.mutiny.converters.uni.ToMono;
 import io.smallrye.mutiny.converters.uni.UniReactorConverters;
 import reactor.core.Disposable;
@@ -33,8 +36,14 @@ public class Discord4jMethodDescriptors {
             Publisher[].class);
     public static final MethodDescriptor TO_MONO_APPLY = MethodDescriptor.ofMethod(ToMono.class, "apply", Mono.class,
             Uni.class);
+    public static final MethodDescriptor TO_FLUX_APPLY = MethodDescriptor.ofMethod(ToFlux.class, "apply", Flux.class,
+            Multi.class);
     public static final MethodDescriptor UNI_REACTOR_CONVERTERS_TO_MONO = MethodDescriptor.ofMethod(UniReactorConverters.class,
             "toMono", ToMono.class);
+
+    public static final MethodDescriptor MULTI_REACTOR_CONVERTERS_TO_FLUX = MethodDescriptor.ofMethod(
+            MultiReactorConverters.class,
+            "toFlux", ToFlux.class);
 
     private Discord4jMethodDescriptors() {
     }

--- a/deployment/src/main/java/io/quarkiverse/discord4j/deployment/Discord4jProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/discord4j/deployment/Discord4jProcessor.java
@@ -345,7 +345,7 @@ public class Discord4jProcessor {
                     mc.readInstanceField(instance.getFieldDescriptor(), mc.getThis()),
                     resultHandles.toArray(new ResultHandle[0]));
 
-            mc.returnValue(Discord4jUtils.convertIfUni(observer.getReturnType(), mc, publisher));
+            mc.returnValue(Discord4jUtils.convertIfMutinyTypes(observer.getReturnType(), mc, publisher));
             cc.close();
         }
 

--- a/deployment/src/main/java/io/quarkiverse/discord4j/deployment/Discord4jUtils.java
+++ b/deployment/src/main/java/io/quarkiverse/discord4j/deployment/Discord4jUtils.java
@@ -19,6 +19,9 @@ public class Discord4jUtils {
         if (typeName.equals(UNI.toString())) {
             resultHandle = bc.invokeVirtualMethod(TO_MONO_APPLY, bc.invokeStaticMethod(UNI_REACTOR_CONVERTERS_TO_MONO),
                     resultHandle);
+        } else if (typeName.equals(MULTI.toString())) {
+            resultHandle = bc.invokeVirtualMethod(TO_FLUX_APPLY, bc.invokeStaticMethod(MULTI_REACTOR_CONVERTERS_TO_FLUX),
+                    resultHandle);
         }
         return resultHandle;
     }

--- a/deployment/src/main/java/io/quarkiverse/discord4j/deployment/Discord4jUtils.java
+++ b/deployment/src/main/java/io/quarkiverse/discord4j/deployment/Discord4jUtils.java
@@ -15,7 +15,7 @@ import io.quarkus.gizmo.ResultHandle;
 public class Discord4jUtils {
     private static final List<DotName> RETURN_TYPES = List.of(FLUX, MONO, MULTI, UNI);
 
-    public static ResultHandle convertIfUni(String typeName, BytecodeCreator bc, ResultHandle resultHandle) {
+    public static ResultHandle convertIfMutinyTypes(String typeName, BytecodeCreator bc, ResultHandle resultHandle) {
         if (typeName.equals(UNI.toString())) {
             resultHandle = bc.invokeVirtualMethod(TO_MONO_APPLY, bc.invokeStaticMethod(UNI_REACTOR_CONVERTERS_TO_MONO),
                     resultHandle);


### PR DESCRIPTION
This ensures Multi handlers are converted to Flux to avoid a class cast exception in a flatMap due to Reactor using Java 6 legacy Reactive Streams APIs.

I also reworked the test because the logs assertion was essentially useless as the test method exited before the assertions could be made.