### PR TITLE
Add correct annotation to handler method

### DIFF
--- a/docs/modules/ROOT/pages/commands.adoc
+++ b/docs/modules/ROOT/pages/commands.adoc
@@ -63,7 +63,7 @@ To listen for the command you just defined, create the following class:
 class FooCommand {
 
     @Command(value="foo", guild="test") // <1>
-    Mono<Void> onFoo(ChatInputInteractionEvent event) { // <2>
+    Mono<Void> onFoo(@GatewayEvent ChatInputInteractionEvent event) { // <2>
         String name = event.getOption("name")
                 .flatMap(ApplicationCommandInteractionOption::getValue)
                 .map(ApplicationCommandInteractionOptionValue::asString)


### PR DESCRIPTION
For command handlers, `@GatewayEvent` annotation is required.