### PR TITLE
Delete only application commands missing from local definitions

### DIFF
--- a/commands/deployment/src/test/java/io/quarkiverse/discord4j/commands/runtime/Discord4jCommandsFilterMissingTest.java
+++ b/commands/deployment/src/test/java/io/quarkiverse/discord4j/commands/runtime/Discord4jCommandsFilterMissingTest.java
@@ -1,0 +1,61 @@
+package io.quarkiverse.discord4j.commands.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import discord4j.discordjson.json.ApplicationCommandData;
+import discord4j.discordjson.json.ApplicationCommandRequest;
+import discord4j.discordjson.possible.Possible;
+
+/**
+ * Verifies the {@code delete-missing} selection logic that regressed in issue #49: registered commands matching a local
+ * JSON definition must be kept, and only commands absent from the local definitions must be selected for deletion.
+ */
+class Discord4jCommandsFilterMissingTest {
+
+    private static final int CHAT_INPUT = 1;
+    private static final int USER = 2;
+
+    @Test
+    void keepsCommandWithMatchingLocalDefinition() {
+        List<ApplicationCommandRequest> local = List.of(localCommand("ping", CHAT_INPUT));
+
+        assertFalse(Discord4jCommandsRegistrar.filterMissing(local).test(discordCommand("ping", CHAT_INPUT)));
+    }
+
+    @Test
+    void deletesCommandAbsentFromLocalDefinitions() {
+        List<ApplicationCommandRequest> local = List.of(localCommand("ping", CHAT_INPUT));
+
+        assertTrue(Discord4jCommandsRegistrar.filterMissing(local).test(discordCommand("pong", CHAT_INPUT)));
+    }
+
+    @Test
+    void deletesCommandWhenOnlyTypeDiffers() {
+        List<ApplicationCommandRequest> local = List.of(localCommand("ping", CHAT_INPUT));
+
+        assertTrue(Discord4jCommandsRegistrar.filterMissing(local).test(discordCommand("ping", USER)));
+    }
+
+    @Test
+    void deletesEveryCommandWhenNoLocalDefinitions() {
+        assertTrue(Discord4jCommandsRegistrar.filterMissing(List.of()).test(discordCommand("ping", CHAT_INPUT)));
+    }
+
+    private ApplicationCommandRequest localCommand(String name, int type) {
+        return ApplicationCommandRequest.builder().name(name).type(type).build();
+    }
+
+    private ApplicationCommandData discordCommand(String name, int type) {
+        ApplicationCommandData command = mock(ApplicationCommandData.class);
+        when(command.name()).thenReturn(name);
+        when(command.type()).thenReturn(Possible.of(type));
+        return command;
+    }
+}

--- a/commands/runtime/src/main/java/io/quarkiverse/discord4j/commands/runtime/Discord4jCommandsRegistrar.java
+++ b/commands/runtime/src/main/java/io/quarkiverse/discord4j/commands/runtime/Discord4jCommandsRegistrar.java
@@ -46,14 +46,20 @@ public class Discord4jCommandsRegistrar {
                 .collect(Collectors.toList());
     }
 
-    private static Predicate<ApplicationCommandData> filter(List<ApplicationCommandRequest> commands) {
-        return c -> {
-            for (ApplicationCommandRequest command : commands) {
-                if (c.name().equals(command.name()) && c.type().equals(command.type())) {
-                    return true;
+    /**
+     * Builds a predicate that selects registered Discord commands which have no matching local JSON definition, i.e. the
+     * commands that should be deleted when {@code delete-missing} is enabled. A command matches a local definition when
+     * both its name and type are equal, so the predicate returns {@code true} (delete) only for commands absent from
+     * {@code localCommands}.
+     */
+    static Predicate<ApplicationCommandData> filterMissing(List<ApplicationCommandRequest> localCommands) {
+        return discordCommand -> {
+            for (ApplicationCommandRequest localCommand : localCommands) {
+                if (discordCommand.name().equals(localCommand.name()) && discordCommand.type().equals(localCommand.type())) {
+                    return false;
                 }
             }
-            return false;
+            return true;
         };
     }
 
@@ -75,7 +81,7 @@ public class Discord4jCommandsRegistrar {
 
             if (config.globalCommands().deleteMissing()) {
                 publishers.add(idMono.flatMapMany(id -> app.getGlobalApplicationCommands(id)
-                        .filter(filter(globalCommandRequests))
+                        .filter(filterMissing(globalCommandRequests))
                         .delayUntil(command -> app.deleteGlobalApplicationCommand(id, command.id().asLong())))
                         .doOnNext(command -> LOGGER.debugf(
                                 "Deleted global command %s as it does not have a matching JSON file in %s",
@@ -98,7 +104,7 @@ public class Discord4jCommandsRegistrar {
 
             if (commandsConfig.deleteMissing()) {
                 publishers.add(idMono.flatMapMany(id -> app.getGuildApplicationCommands(id, guildId)
-                        .filter(filter(guildCommandRequests))
+                        .filter(filterMissing(guildCommandRequests))
                         .delayUntil(command -> app.deleteGuildApplicationCommand(id, guildId, command.id().asLong())))
                         .doOnNext(command -> LOGGER.debugf(
                                 "Deleted guild command %s from guild %s (%s) as it does not have a matching JSON file in %s",

--- a/deployment/src/test/java/io/quarkiverse/discord4j/test/Discord4jMetricsTest.java
+++ b/deployment/src/test/java/io/quarkiverse/discord4j/test/Discord4jMetricsTest.java
@@ -1,8 +1,10 @@
 package io.quarkiverse.discord4j.test;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.time.Duration;
 import java.util.List;
 
 import jakarta.inject.Inject;
@@ -24,6 +26,7 @@ public class Discord4jMetricsTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClass(TestMeterRegistryProducer.class))
             .withConfigurationResource("metrics-application.properties");
 
     @Inject
@@ -43,12 +46,15 @@ public class Discord4jMetricsTest {
     public void testMetrics() {
         List<Guild> guilds = gateway.getGuilds().collectList().block();
         assertNotNull(guilds);
-        assertEquals(guilds.size(), gauge(Metrics.GUILDS_METRIC_NAME).intValue());
+        await().atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> assertEquals(guilds.size(), gauge(Metrics.GUILDS_METRIC_NAME).intValue()));
 
         List<VoiceConnection> voiceConnections = gateway.getGuilds().flatMap(Guild::getVoiceConnection).collectList()
                 .block();
         assertNotNull(voiceConnections);
-        assertEquals(voiceConnections.size(), gauge(Metrics.VOICE_CONNECTIONS_METRIC_NAME).intValue());
+        await().atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> assertEquals(voiceConnections.size(),
+                        gauge(Metrics.VOICE_CONNECTIONS_METRIC_NAME).intValue()));
     }
 
     private Double gauge(String name) {

--- a/deployment/src/test/java/io/quarkiverse/discord4j/test/TestMeterRegistryProducer.java
+++ b/deployment/src/test/java/io/quarkiverse/discord4j/test/TestMeterRegistryProducer.java
@@ -1,0 +1,20 @@
+package io.quarkiverse.discord4j.test;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+/**
+ * Supplies a concrete {@link SimpleMeterRegistry} so the root {@code CompositeMeterRegistry} has a child registry
+ * during tests. Without a child registry every gauge reads {@code 0} regardless of its backing value, because a
+ * composite delegates reads to its children. Production deployments get a child from a real registry exporter.
+ */
+public class TestMeterRegistryProducer {
+
+    @Produces
+    @Singleton
+    SimpleMeterRegistry simpleMeterRegistry() {
+        return new SimpleMeterRegistry();
+    }
+}

--- a/docs/modules/ROOT/pages/commands.adoc
+++ b/docs/modules/ROOT/pages/commands.adoc
@@ -22,7 +22,7 @@ Add the `quarkus-discord4j-commands` artifact to your Quarkus app:
 
 Before you can start listening for commands in code, you first need to define your application commands and register them in Discord so they can be used. The easiest way to do this is by defining your commands using JSON. Quarkus Discord Bot will automatically serialize and register the JSON files found in `META-INF/commands` and subdirectories as application commands (when configured to do so).
 
-TIP: Discord supports two types of application commands: global commands and guild commands. Global commands take an hour to propagate after being registered, so it's recommended to register your commands as guild commands while you're developing.
+TIP: Discord supports two types of application commands: global commands and guild commands. Guild commands update instantly, so it's recommended to register your commands as guild commands while you're developing for faster iteration.
 
 Let's create a guild command by creating the following JSON file in `META-INF/commands/test`:
 [source,json]


### PR DESCRIPTION
## Describe your changes:

The `delete-missing` predicate in the commands registrar was inverted: it matched commands present in the local JSON definitions and deleted them, so global and guild commands were removed right after being registered. It now deletes only commands absent from the local definitions, covered by a unit test.

Also updates an outdated note on global command propagation to match Discord's current documentation.

### Verification

Tested against the reproducer from #49 ([artkonr/discord-command-err-reproducer](https://github.com/artkonr/discord-command-err-reproducer)): built the extension with the fix, installed to mavenLocal, ran the reproducer with `delete-missing=true` and confirmed the `testcommand` command persists in Discord (verified via API: command ID `1517903223699280024`). Without the fix, the inverted predicate deletes commands that match local JSON definitions.

The reproducer required the following updates to work with the current extension (originally built for Quarkus 3.17.5):

- `gradle.properties`: `quarkusPluginVersion` and `quarkusPlatformVersion` updated to `3.35.2`
- `build.gradle`: `quarkusDiscordVersion` updated to `999-SNAPSHOT`
- `build.gradle`: Kotlin plugin updated from `2.0.21` to `2.3.21` (Quarkus 3.35.2 BOM pulls `kotlin-stdlib 2.3.21`, which is incompatible with older Kotlin compiler versions)
- `gradle/wrapper/gradle-wrapper.properties`: Gradle wrapper updated from `8.9` to `9.6.0` (required for Java 21 and Kotlin 2.3.x compatibility)
- `application.properties`: added `quarkus.discord4j.token=${DISCORD_BOT_TOKEN}` (required for production mode startup)

### Note: flaky metrics test

> This PR also stabilises `Discord4jMetricsTest`, which was failing intermittently on `main` (`expected: <1> but was: <0>`). In tests the injected `MeterRegistry` is a `CompositeMeterRegistry` with no child registry, so every gauge reads `0` regardless of its backing value; the assertion only passed when the guild count happened to be `0` too. The fix registers a `SimpleMeterRegistry` for the test and keeps the real assertion (gauge == guild count). Production is unaffected, since a registry exporter provides the child there.

See https://github.com/quarkiverse/quarkus-discord4j/actions/runs/27233701258/job/80420141231

---

- Closes #49