### PR TITLE
Fix crash when routing interactions across multiple commands

### DIFF
--- a/commands/deployment/src/test/java/io/quarkiverse/discord4j/commands/runtime/Discord4jCommandsFilterTest.java
+++ b/commands/deployment/src/test/java/io/quarkiverse/discord4j/commands/runtime/Discord4jCommandsFilterTest.java
@@ -54,6 +54,14 @@ class Discord4jCommandsFilterTest {
         assertFalse(filter.test(event, "ping", Optional.of("test"), Optional.empty(), Optional.empty()));
     }
 
+    @Test
+    void nonMatchingCommandNameIsRejected() {
+        Discord4jCommandsFilter filter = filter(Map.of());
+        InteractionCreateEvent event = interaction(Optional.of(GUILD), "action");
+
+        assertFalse(filter.test(event, "status", Optional.of(""), Optional.empty(), Optional.empty()));
+    }
+
     private Discord4jCommandsFilter filter(Map<String, GuildCommandsConfig> guildCommands) {
         Discord4jCommandsConfig config = mock(Discord4jCommandsConfig.class);
         when(config.guildCommands()).thenReturn(guildCommands);

--- a/commands/runtime/src/main/java/io/quarkiverse/discord4j/commands/runtime/Discord4jCommandsFilter.java
+++ b/commands/runtime/src/main/java/io/quarkiverse/discord4j/commands/runtime/Discord4jCommandsFilter.java
@@ -35,6 +35,6 @@ public class Discord4jCommandsFilter {
                 .map(interaction -> subCommandGroup.map(s -> interaction.getOption(s)
                         .flatMap(option -> subCommand.flatMap(option::getOption)).isPresent())
                         .orElseGet(() -> subCommand.map(s -> interaction.getOption(s).isPresent()).orElse(true)))
-                .get();
+                .orElse(false);
     }
 }

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -22,6 +22,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.quarkiverse.discord4j</groupId>
+      <artifactId>quarkus-discord4j-commands</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-rest</artifactId>
     </dependency>

--- a/integration-tests/src/test/java/io/quarkiverse/discord4j/it/Discord4jMultipleCommandsTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/discord4j/it/Discord4jMultipleCommandsTest.java
@@ -1,0 +1,88 @@
+package io.quarkiverse.discord4j.it;
+
+import static io.quarkiverse.discord4j.testing.Discord4jTesting.defaultShardInfo;
+import static io.quarkiverse.discord4j.testing.Discord4jTesting.given;
+import static io.quarkiverse.discord4j.testing.Discord4jTesting.mockGateway;
+import static io.quarkiverse.discord4j.testing.Discord4jTesting.payloadFromClasspath;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
+import discord4j.core.object.command.Interaction;
+import discord4j.discordjson.json.InteractionData;
+import io.quarkiverse.discord4j.commands.Command;
+import io.quarkiverse.discord4j.commands.SubCommand;
+import io.quarkiverse.discord4j.testing.Discord4jTest;
+import io.quarkiverse.discord4j.testing.dsl.ValidatableEventHandling;
+import io.quarkus.test.junit.QuarkusTest;
+import reactor.core.publisher.Mono;
+
+@QuarkusTest
+@Discord4jTest
+public class Discord4jMultipleCommandsTest {
+
+    @Inject
+    ObjectMapper mapper;
+
+    @BeforeEach
+    void resetCounters() {
+        StatusCommand.invocations.set(0);
+        ActionCommand.invocations.set(0);
+    }
+
+    @Test
+    void simpleCommandIsRoutedWithoutErrors() throws Exception {
+        ValidatableEventHandling response = given().when()
+                .publish(interactionEvent("status-interaction.json"))
+                .then();
+
+        await().atMost(Duration.ofSeconds(5)).untilAtomic(StatusCommand.invocations, greaterThanOrEqualTo(1));
+
+        response.noErrors();
+    }
+
+    @Test
+    void subCommandIsRoutedWithoutErrors() throws Exception {
+        ValidatableEventHandling response = given().when()
+                .publish(interactionEvent("action-do-interaction.json"))
+                .then();
+
+        await().atMost(Duration.ofSeconds(5)).untilAtomic(ActionCommand.invocations, greaterThanOrEqualTo(1));
+
+        response.noErrors();
+    }
+
+    private ChatInputInteractionEvent interactionEvent(String resource) throws Exception {
+        InteractionData data = mapper.readValue(payloadFromClasspath("/" + resource), InteractionData.class);
+        return new ChatInputInteractionEvent(mockGateway(), defaultShardInfo(), new Interaction(mockGateway(), data));
+    }
+
+    static class StatusCommand {
+        static final AtomicInteger invocations = new AtomicInteger();
+
+        @Command("status")
+        Mono<Void> onChatInputInteraction(ChatInputInteractionEvent event) {
+            return Mono.fromRunnable(invocations::incrementAndGet);
+        }
+    }
+
+    @Command("action")
+    static class ActionCommand {
+        static final AtomicInteger invocations = new AtomicInteger();
+
+        @SubCommand("do")
+        Mono<Void> onChatInputInteraction(ChatInputInteractionEvent event) {
+            return Mono.fromRunnable(invocations::incrementAndGet);
+        }
+    }
+}

--- a/integration-tests/src/test/resources/action-do-interaction.json
+++ b/integration-tests/src/test/resources/action-do-interaction.json
@@ -1,0 +1,18 @@
+{
+  "id": "1",
+  "application_id": "0",
+  "type": 2,
+  "data": {
+    "id": 1,
+    "name": "action",
+    "type": 1,
+    "options": [
+      {
+        "name": "do",
+        "type": 1
+      }
+    ]
+  },
+  "token": "",
+  "version": 1
+}

--- a/integration-tests/src/test/resources/status-interaction.json
+++ b/integration-tests/src/test/resources/status-interaction.json
@@ -1,0 +1,12 @@
+{
+  "id": "0",
+  "application_id": "0",
+  "type": 2,
+  "data": {
+    "id": 0,
+    "name": "status",
+    "type": 1
+  },
+  "token": "",
+  "version": 1
+}


### PR DESCRIPTION
## Describe your changes

`Discord4jCommandsFilter.test()` called `.get()` on an `Optional` that becomes empty whenever a command name doesn't match the incoming interaction. With a single command registered this never happened, but with two or more commands, every interaction is checked against every command's filter, so a mismatch on any of them threw `NoSuchElementException` and crashed the event routing. It now returns `false` in that case, as intended, covered by a unit test and an end-to-end test routing two real commands.

---

- Closes #52
